### PR TITLE
Breaking change of energinet-price API

### DIFF
--- a/templates/definition/tariff/energinet-price.yaml
+++ b/templates/definition/tariff/energinet-price.yaml
@@ -17,15 +17,22 @@ render: |
   {{ include "tariff-base" . }}
   forecast:
     source: http
-    uri: https://api.energidataservice.dk/dataset/Elspotprices?filter={"PriceArea":["{{ .region }}"]}
+    uri: https://api.energidataservice.dk/dataset/DayAheadPrices?start=now&filter={"PriceArea":["{{ .region }}"]}
     jq: |
-      [.records[] |
-        {
-          start: (.HourUTC[0:13] + ":00:00Z"),
-          end: (.HourUTC[0:13] 
-                | strptime("%Y-%m-%dT%H") 
-                | mktime + 3600 
+      [.records[]
+        | {
+          start: (.TimeUTC[0:13] + ":00:00Z"),
+          end: (.TimeUTC[0:13]
+                | strptime("%Y-%m-%dT%H")
+                | mktime + 3600
                 | strftime("%Y-%m-%dT%H:%M:%SZ")),
-          value: .SpotPriceDKK / 1e3
+          value: .DayAheadPriceDKK / 1e3
         }
-      ] | tostring
+      ]
+      | group_by(.start)
+      | map({
+          start: .[0].start,
+          end: .[0].end,
+          value: (map(.value) | add / length)
+        })
+      | tostring


### PR DESCRIPTION
The dataset [Elspot Prices](https://www.energidataservice.dk/tso-electricity/Elspotprices) has been discontinued with effect September 30, 2025. (for reference, see the news here: https://energidataservice.dk/news) 

Instead, the dataset [Day-Ahead Prices](https://www.energidataservice.dk/tso-electricity/DayAheadPrices) is now provided, which returns prices in 15-minute resolution. The first available data is for October 1, 2025. 

The suggested pull request should compute hourly average prices in DKK per kWh for use in evcc


**Please review thoroughly -- I am not at all sure about what I am doing! ;-)**